### PR TITLE
Update UserGroupFieldModel.php

### DIFF
--- a/src/models/UserGroupFieldModel.php
+++ b/src/models/UserGroupFieldModel.php
@@ -53,7 +53,7 @@ class UserGroupFieldModel extends Model
     {
         if (!$this->_groups) {
             $this->_groups = array_filter(Craft::$app->getUserGroups()->getAllGroups(), function(UserGroup $userGroup) {
-                return \in_array($userGroup->uid, $this->groupIds, false);
+                return \in_array($userGroup->uid, $this->getGroupIds(), false);
             });
         }
 


### PR DESCRIPTION
in_array requires second parameter as array and when there is no user group selected then a NULL value is being sent since method getGroupIds was not used at all! This will fix the issue even when no user group is selected at all.