### PR TITLE
Fix composer package name in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ To install the plugin, follow these instructions.
 
 2. Then tell Composer to load the plugin:
 
-        composer require superbigco/craft-usergroupfield
+        composer require superbig/craft-usergroupfield
 
 3. In the Control Panel, go to Settings → Plugins and click the “Install” button for User Group Field.
 


### PR DESCRIPTION
Tiny docco fix - the composer pkg name in the README is not quite right