### PR TITLE
add a hidden field when using checkbox UI so that empty checkboxes ar…

### DIFF
--- a/src/templates/_components/fields/UserGroupFieldField_input.twig
+++ b/src/templates/_components/fields/UserGroupFieldField_input.twig
@@ -23,6 +23,9 @@
         options: userGroups,
         value: firstGroupId}) }}
 {% elseif mode == 'checkboxes' %}
+    {{ forms.hidden({
+        id: name,
+        name: name} )}}
     {{ forms.checkboxSelect({
         id: name,
         name: name,


### PR DESCRIPTION
Fixes #11 and #7 by adding an empty hidden field to the checkbox UI, ensuring that the field is always present in the POST to save the element its on, even if there are no groups selected