### PR TITLE
User groups not getting saved

### DIFF
--- a/src/fields/UserGroupFieldField.php
+++ b/src/fields/UserGroupFieldField.php
@@ -95,10 +95,13 @@ class UserGroupFieldField extends Field
             }
         }
 
-
-        return new UserGroupFieldModel([
-            'groupIds' => $value,
-        ]);
+        if (is_a($value, UserGroupFieldModel::class)) {
+            return $value;
+        } else {
+            return new UserGroupFieldModel([
+                'groupIds' => $value
+            ]);
+        }
     }
 
     /**


### PR DESCRIPTION
fix for #15.
normailzeValue is getting called multiple times while the $value is already an UserGroupFieldModel, this way the groupIds was getting set as a Model as well and not the array with the groupIds