### PR TITLE
Fix plugin name reference in schema version check

### DIFF
--- a/src/migrations/m220604_000000_verbb_migration.php
+++ b/src/migrations/m220604_000000_verbb_migration.php
@@ -17,7 +17,7 @@ class m220604_000000_verbb_migration extends Migration
 
         // Don't make the same config changes twice
         $projectConfig = Craft::$app->getProjectConfig();
-        $schemaVersion = $projectConfig->get('plugins.tablemaker.schemaVersion', true);
+        $schemaVersion = $projectConfig->get('plugins.user-group-field.schemaVersion', true);
 
         if (version_compare($schemaVersion, '2.0.0', '>=')) {
             return true;


### PR DESCRIPTION
We were unable to deploy a site because post deployment it would always run the `m220604_000000_verbb_migration` migration, which fails because we don't allow admin changes on staging and prod. The migration does check whether it's been run before, but it mistakenly looks up the schema version for `plugins.tablemaker.schemaVersion`, which doesn't exist in our site, so it will always attempt to run (and fail the deployment). This just fixes the name.